### PR TITLE
Changed current_user to self in model helpers

### DIFF
--- a/app/models/policy_manager/concerns/user_behavior.rb
+++ b/app/models/policy_manager/concerns/user_behavior.rb
@@ -87,14 +87,14 @@ module PolicyManager::Concerns::UserBehavior
   def confirm_all_policies!
     pending_policies.each do |c|
       term = c.terms.last
-      current_user.handle_policy_for(term).accept!
+      self.handle_policy_for(term).accept!
     end
   end
 
   def reject_all_policies!
     pending_policies.each do |c|
       term = c.terms.last
-      current_user.handle_policy_for(term).reject!
+      self.handle_policy_for(term).reject!
     end
   end
 


### PR DESCRIPTION
I'ts poor practice to use current_user in models ([example stack overflow answer here](https://stackoverflow.com/questions/1568218/access-to-current-user-from-within-a-model-in-ruby-on-rails?lq=1)) and it doesn't work out fo the box anyway. Instead, I recommend changing this to "self" which is contextually aware and these methods can be easily used in things like an "after_create" method without having to expose a current_user concept to the model.