### PR TITLE
Remove footer with attribution

### DIFF
--- a/app/views/layouts/policy_manager/application.html.erb
+++ b/app/views/layouts/policy_manager/application.html.erb
@@ -33,7 +33,6 @@
     <div class="page">
       <div class="page-main">
         <%= render partial: "policy_manager/shared/header" %>
-      
         <div class="my-3 my-md-5">
           <div class="container">
             <p id="notice">
@@ -43,10 +42,7 @@
           </div>
         </div>
       </div>
-
-      <%= render partial: "policy_manager/shared/footer" %>
     </div>
  
-
 </body>
 </html>


### PR DESCRIPTION
This isn't great for users that are using their portal to manage portability requests...